### PR TITLE
Fix issues where if scale is more than 25 image gets cut off

### DIFF
--- a/dist/pixelit.js
+++ b/dist/pixelit.js
@@ -169,8 +169,8 @@ class pixelit {
     const tempCanvas = document.createElement("canvas");
     
     // Set temp canvas width/height & hide (fixes higher scaled cutting off image bottom)
-    tempCanvas.width = this.drawTo.width
-    tempCanvas.height = this.drawTo.height
+    tempCanvas.width = this.drawto.width
+    tempCanvas.height = this.drawto.height
     tempCanvas.style.visibility = "hidden"
     tempCanvas.style.position = "fixed"
     tempCanvas.style.top = "0"

--- a/dist/pixelit.js
+++ b/dist/pixelit.js
@@ -167,6 +167,14 @@ class pixelit {
 
     //make temporary canvas to make new scaled copy
     const tempCanvas = document.createElement("canvas");
+    
+    // Set temp canvas width/height & hide (fixes higher scaled cutting off image bottom)
+    tempCanvas.width = this.drawTo.width
+    tempCanvas.height = this.drawTo.height
+    tempCanvas.style.visibility = "hidden"
+    tempCanvas.style.position = "fixed"
+    tempCanvas.style.top = "0"
+    tempCanvas.style.left = "0"
 
     //corner case of bigger images, increase the temporary canvas size to fit everything
     if(this.drawto.width > 800 || this.drawto.width > 800 ){


### PR DESCRIPTION
First off great job on the package it works wonderful and was just what I needed for my use case.

I ran into 1 issue while using it. If trying to use a pixel scale over 25 the bottom of my image would begin to get cut off and it would get worse and worse the higher the scale went.

`Example:`

![issue-1](https://user-images.githubusercontent.com/61068742/138569745-79e04e46-b119-4df9-b8ba-c61e98c87069.png)

![issue-2](https://user-images.githubusercontent.com/61068742/138569749-e6af3291-7426-4880-a728-6ae660a9122b.png)

`Proposed Fix:`
After a little debugging I realized the temporarily generated canvas had no set size when added to the dom. This would result in higher scaled images to be cut off before being drawn back to the main canvas. 

By adding these lines to the pixelate method:

```js
    tempCanvas.width = this.drawTo.width
    tempCanvas.height = this.drawTo.height
    tempCanvas.style.visibility = "hidden"
    tempCanvas.style.position = "fixed"
    tempCanvas.style.top = "0"
    tempCanvas.style.left = "0"
```
We hide the temporary canvas and we make sure the temporary canvas is the size of the original image so no cutoff can occur.

`With proposed changes:`

![fix-1](https://user-images.githubusercontent.com/61068742/138569827-9c582fd8-5f29-402c-a2cb-797b6bc3e043.png)

I only made this change to the non minified disto as you did not include the code to minify the normal distro.